### PR TITLE
Add MPSI math Obsidian notes

### DIFF
--- a/maths-mpsi/Algèbre - Calcul matriciel et déterminants.md
+++ b/maths-mpsi/Algèbre - Calcul matriciel et déterminants.md
@@ -1,0 +1,37 @@
+---
+tags: [MPSI, Algèbre, Déterminants]
+---
+
+# Algèbre – Calcul matriciel et déterminants
+
+## Définitions essentielles
+- **Déterminant** : application \(\det : \mathcal{M}_n(\mathbb{K}) \to \mathbb{K}\) multilinéaire, alternée, normalisée par \(\det I_n = 1\).
+- **Cofacteur** : \(C_{ij} = (-1)^{i+j}M_{ij}\) où \(M_{ij}\) est le mineur obtenu en supprimant la ligne \(i\) et la colonne \(j\).
+- **Adjugée** : transposée de la matrice des cofacteurs; \(A \cdot \operatorname{Adj}(A) = \det(A) I_n\).
+
+## Propriétés fondamentales
+- **Multiplicativité** : \(\det(AB) = \det A \cdot \det B\).
+- **Inversibilité** : \(A\) inversible ssi \(\det A \neq 0\).
+- **Opérations élémentaires** : échange de deux lignes change le signe du déterminant; ajout d'un multiple d'une ligne n'en change pas la valeur; multiplication d'une ligne par \(\lambda\) multiplie le déterminant par \(\lambda\).
+- **Développement de Laplace** : calculer \(\det A\) par expansion le long d'une ligne ou colonne.
+
+## Méthodes de calcul
+1. **Triangularisation** : réduire \(A\) en matrice triangulaire supérieure via Gauss; le déterminant est alors le produit diagonal.
+2. **Déterminants remarquables** : Vandermonde, circulants, matrices de Cauchy.
+3. **Utilisation de symétries** : matrices symétriques, antisymétriques, blocs.
+4. **Déterminant d'une application linéaire** : calcul via matrice dans une base orthonormée.
+5. **Systèmes de Cramer** : résolution de \(Ax=b\) lorsque \(\det A \neq 0\).
+
+## Exemples clés
+- Déterminant de Vandermonde : \(\prod_{i<j} (x_j - x_i)\).
+- Calcul de \(\det(I_n + uv^T) = 1 + v^T u\) (formule de Sherman-Morrison).
+- Déterminant d'une matrice diagonale par blocs = produit des déterminants des blocs.
+
+## Exercices types
+- Calculer \(\det(A)\) pour \(A\) matrice de taille 3 associée à un produit vectoriel.
+- Montrer que \(\det(\exp A) = \exp(\operatorname{tr} A)\).
+- Résoudre un système par Cramer et interpréter géométriquement.
+
+## Connexions utiles
+- Voir [[Algèbre – Matrices et applications linéaires]] pour l'usage des déterminants dans l'inversibilité.
+- Voir [[Géométrie – Produit scalaire et orthogonalité]] pour l'interprétation géométrique du déterminant en dimension 3.

--- a/maths-mpsi/Algèbre - Espaces vectoriels.md
+++ b/maths-mpsi/Algèbre - Espaces vectoriels.md
@@ -1,0 +1,39 @@
+---
+tags: [MPSI, Algèbre, Espaces vectoriels]
+---
+
+# Algèbre – Espaces vectoriels
+
+## Définitions essentielles
+- **Espace vectoriel (EV)** : ensemble \(E\) muni d'une addition et d'une multiplication par un scalaire satisfaisant les axiomes.
+- **Sous-espace vectoriel (SEV)** : sous-ensemble non vide stable par addition et multiplication par un scalaire.
+- **Famille génératrice** : \(\{v_1,\ldots,v_p\}\) telle que tout \(v\in E\) est combinaison linéaire des \(v_i\).
+- **Famille libre** : seule combinaison linéaire nulle est la triviale.
+- **Base** : famille à la fois libre et génératrice; sa cardinalité est la dimension de \(E\).
+
+## Propriétés fondamentales
+- Toute famille génératrice contient une base; toute famille libre se complète en base.
+- **Dimension** : si \(E\) est de dimension finie, toutes les bases ont le même cardinal.
+- **Formule du rang** : pour une application linéaire \(f : E \to F\), \(\dim \ker f + \dim \operatorname{Im} f = \dim E\).
+- **Théorème de la dimension** : pour des SEV \(F,G\subset E\), \(\dim(F+G) = \dim F + \dim G - \dim(F\cap G)\).
+
+## Méthodes de résolution
+1. **Tester la stabilité** pour identifier un SEV (vérifier 0, addition, homothétie).
+2. **Élimination de Gauss** pour déterminer la liberté/génération et calculer des bases.
+3. **Rang d'une matrice** : déterminer \(\dim \operatorname{Im} f\) via les pivots.
+4. **Changement de base** : calculer les matrices de passage pour simplifier les calculs.
+5. **Projection et somme directe** : caractériser les SEV complémentaires.
+
+## Exemples clés
+- \(\mathbb{R}^n\), espaces de polynômes \(\mathbb{R}_n[X]\), espaces de matrices \(\mathcal{M}_{n,p}(\mathbb{R})\).
+- Noyau d'une application linéaire : solutions d'un système homogène.
+- Lien entre équations différentielles linéaires et EV de solutions.
+
+## Exercices types
+- Déterminer une base de l'espace des polynômes de degré \(\leqslant 3\) annulant \(1\) en 0.
+- Résoudre \(f(x+y)=f(x)+f(y)\) sur \(\mathbb{R}\) sous hypothèse de continuité et interpréter comme morphisme d'EV.
+- Chercher la dimension de \(E = \{(x,y,z) \in \mathbb{R}^3 : x+y+z=0\}\).
+
+## Connexions utiles
+- Voir [[Algèbre – Matrices et applications linéaires]] pour les représentations matricielles.
+- Voir [[Algèbre – Calcul matriciel et déterminants]] pour les outils de rang.

--- a/maths-mpsi/Algèbre - Matrices et applications linéaires.md
+++ b/maths-mpsi/Algèbre - Matrices et applications linéaires.md
@@ -1,0 +1,38 @@
+---
+tags: [MPSI, Algèbre, Matrices]
+---
+
+# Algèbre – Matrices et applications linéaires
+
+## Définitions essentielles
+- **Application linéaire** : \(f : E \to F\) telle que \(f(u+v)=f(u)+f(v)\) et \(f(\lambda u)=\lambda f(u)\).
+- **Matrice associée** : représentation de \(f\) dans des bases choisies; notée \(\mathrm{Mat}_{\mathcal{B},\mathcal{C}}(f)\).
+- **Composition** : correspond au produit matriciel; identité \(I_n\) est neutre.
+- **Inverse** : matrice \(A^{-1}\) telle que \(AA^{-1}=I\).
+
+## Propriétés fondamentales
+- **Rang** : dimension de l'image; invariant par changement de base.
+- **Noyau** : solutions de \(Ax=0\); dimension liée par \(\dim \ker A = n - \operatorname{rg} A\).
+- **Théorème de l'application linéaire** : \(f\) est inversible ssi \(\operatorname{rg} f = \dim E\).
+- **Réduction de matrices** : opérations élémentaires ne changent pas le rang mais simplifient la matrice.
+
+## Méthodes usuelles
+1. **Pivot de Gauss** : résoudre \(Ax=b\), déterminer \(A^{-1}\) si elle existe.
+2. **Calcul de l'image et du noyau** : utiliser un système de générateurs pour la base de l'image.
+3. **Composition** : vérifier que \(\mathrm{Mat}(g\circ f)=\mathrm{Mat}(g)\cdot\mathrm{Mat}(f)\).
+4. **Matrices particulières** : projecteurs, symétries, endomorphismes diagonalisables.
+5. **Exponentielle de matrice** : \(e^A = \sum_{k=0}^{+\infty} \frac{A^k}{k!}\) pour résoudre des systèmes linéaires différentielles.
+
+## Exemples clés
+- Matrices triangulaires : déterminant = produit des éléments diagonaux.
+- Matrices de passage entre bases canoniques et orthonormales.
+- Matrices d'un endomorphisme de projection, rotation, symétrie.
+
+## Exercices types
+- Calculer \(A^n\) pour une matrice triangulaire supérieure.
+- Déterminer la dimension de \(\operatorname{Im} f\) et \(\ker f\) pour \(f\) définie par \(f(x,y,z) = (x+y, y+z, x+z)\).
+- Trouver la matrice de l'application \(f : \mathbb{R}_2[X] \to \mathbb{R}_2[X]\) définie par \(f(P) = P' + P\).
+
+## Connexions utiles
+- Voir [[Algèbre – Calcul matriciel et déterminants]] pour les formules de déterminants.
+- Voir [[Algèbre – Espaces vectoriels]] pour la notion de base et dimension.

--- a/maths-mpsi/Analyse - Fonctions d'une variable réelle.md
+++ b/maths-mpsi/Analyse - Fonctions d'une variable réelle.md
@@ -1,0 +1,41 @@
+---
+tags: [MPSI, Analyse, Fonctions]
+---
+
+# Analyse – Fonctions d'une variable réelle
+
+## Définitions essentielles
+- **Limite en un point** : \(\lim_{x\to a} f(x)=\ell\) signifie \(\forall \varepsilon>0,\ \exists \eta>0 : 0<|x-a|<\eta \Rightarrow |f(x)-\ell|<\varepsilon\).
+- **Continuité** : \(f\) est continue en \(a\) si \(\lim_{x\to a} f(x) = f(a)\).
+- **Dérivabilité** : \(f\) est dérivable en \(a\) si \(\lim_{h\to0} \frac{f(a+h)-f(a)}{h}\) existe; notée \(f'(a)\).
+- **Classe \(\mathcal{C}^k\)** : \(f\) admet des dérivées continues jusqu'à l'ordre \(k\).
+
+## Théorèmes clés
+- **Théorème des valeurs intermédiaires (TVI)** : pour \(f\) continue sur \([a,b]\), toute valeur intermédiaire est atteinte.
+- **Théorème de Rolle** et **des accroissements finis** : fournit \(c\in(a,b)\) tel que \(f'(c)=0\) ou \(f'(c)=\frac{f(b)-f(a)}{b-a}\).
+- **Formule de Taylor avec reste** : \(f(x)=\sum_{k=0}^n \frac{f^{(k)}(a)}{k!}(x-a)^k + R_n(x)\) avec estimation du reste (Lagrange, intégral).
+- **Théorème de continuité des fonctions monotones** : une fonction monotone sur un intervalle est continue sauf en un nombre au plus dénombrable de points.
+- **Réciproque locale** : si \(f\) est \(\mathcal{C}^1\), strictement monotone et \(f'(a)\neq 0\), alors \(f\) admet une réciproque \(\mathcal{C}^1\) près de \(a\).
+
+## Méthodes d'étude
+1. **Tableaux de variation** : dériver, étudier le signe de \(f'\) et synthétiser les comportements.
+2. **Développements limités (DL)** : calculer un DL autour d'un point pour obtenir limites, équivalents et tangentes.
+3. **Comparaison aux fonctions usuelles** : exponentielle, logarithme, trigonométriques.
+4. **Étude de la convexité** : analyser \(f''\) ou les variations de \(f'\) pour déduire points d'inflexion et inégalités (Jensen, inégalité des accroissements finis).
+5. **Changements de variable** : substitution, composition, symétries pour simplifier calculs.
+
+## Exemples incontournables
+- Fonctions polynomiales, rationnelles, exponentielles, logarithmes, trigonométriques et compositions.
+- Fonction \(x \mapsto x^x\) pour l'étude des limites via \(\ln\).
+- Fonction \(x \mapsto \frac{\sin x}{x}\) et ses limites ainsi que son DL.
+- Étude des équations transcendantes \(\ln x = x-2\), \(\cos x = x\).
+
+## Exercices types
+- Résoudre des équations \(f(x)=0\) en combinant TVI et variations.
+- Déterminer des équivalents \(x\to0\) ou \(x\to+\infty\) de fonctions rationnelles ou exponentielles.
+- Etudier les asymptotes et courbes représentatives de fonctions rationnelles.
+- Analyser la dérivabilité et continuité de fonctions définies par morceaux.
+
+## Connexions utiles
+- Voir [[Analyse – Suites et limites]] pour la comparaison par suites extraites.
+- Voir [[Analyse – Intégration sur un segment]] pour les primitives et l'étude des variations par intégrale.

--- a/maths-mpsi/Analyse - Intégration sur un segment.md
+++ b/maths-mpsi/Analyse - Intégration sur un segment.md
@@ -1,0 +1,39 @@
+---
+tags: [MPSI, Analyse, Intégrales]
+---
+
+# Analyse – Intégration sur un segment
+
+## Définitions essentielles
+- **Fonction intégrable** : fonction continue par morceaux sur \([a,b]\), dont l'intégrale de Riemann existe.
+- **Primitive** : \(F\) est une primitive de \(f\) sur \([a,b]\) si \(F' = f\) et \(F\) est \(\mathcal{C}^1\).
+- **Intégrale définie** : \(\int_a^b f(x)\,\mathrm{d}x = F(b)-F(a)\) pour une primitive \(F\) de \(f\).
+
+## Théorèmes clés
+- **Linéarité et additivité** : \(\int_a^b (\alpha f + \beta g) = \alpha \int_a^b f + \beta \int_a^b g\) et \(\int_a^b f = \int_a^c f + \int_c^b f\).
+- **Inégalité de la moyenne** : \(m(b-a) \leqslant \int_a^b f \leqslant M(b-a)\) si \(m\leqslant f \leqslant M\).
+- **Théorème fondamental de l'analyse** : si \(F(x) = \int_a^x f(t)\,dt\), alors \(F\) est \(\mathcal{C}^1\) et \(F'=f\).
+- **Changement de variable** : \(\int_a^b f(u(x))u'(x)\,dx = \int_{u(a)}^{u(b)} f(t)\,dt\).
+- **Intégration par parties** : \(\int_a^b u'(x)v(x)\,dx = [u(x)v(x)]_a^b - \int_a^b u(x)v'(x)\,dx\).
+
+## Méthodes d'intégration
+1. **Recherche d'une primitive** : identifier des fonctions usuelles (polynômes, exponentielle, trigonométriques, rationnelles).
+2. **IPP** : choisir judicieusement \(u\) et \(v'\) pour simplifier l'intégrale.
+3. **Changements de variable** : trigonométriques, exponentiels, substitution affine pour réduire à une forme simple.
+4. **Comparaison** : majorer/minorer l'intégrale pour obtenir des encadrements ou limites.
+5. **Utilisation des symétries** : intégrales sur \([-a,a]\) avec fonctions paires/impaires.
+
+## Exemples importants
+- Calculs de moments \(\int_a^b x^n\,dx\), intégrales trigonométriques \(\int \sin^n x\,dx\), \(\int e^{ax}\cos bx\,dx\).
+- Intégrales de fonctions définies par morceaux et notion d'aire.
+- Intégrales dépendant d'un paramètre \(I(t)=\int_a^b f(x,t)\,dx\) : continuité, dérivation sous le signe intégral.
+
+## Exercices types
+- Déterminer \(\int_0^1 \ln(1+x)\,dx\) via IPP.
+- Étudier la fonction \(I(a)=\int_0^1 \frac{x^a-1}{\ln x}\,dx\) et montrer sa continuité.
+- Comparer \(\int_0^1 \frac{dx}{\sqrt{x}}\) et \(\int_0^1 \frac{dx}{x}\) (divergence au bord).
+- Calculer la valeur moyenne \(\frac{1}{b-a}\int_a^b f\) et l'interpréter géométriquement.
+
+## Connexions utiles
+- Voir [[Analyse – Fonctions d'une variable réelle]] pour les primitives et DL.
+- Voir [[Analyse – Séries numériques]] pour l'échange somme-intégrale.

--- a/maths-mpsi/Analyse - Suites et limites.md
+++ b/maths-mpsi/Analyse - Suites et limites.md
@@ -1,0 +1,41 @@
+---
+tags: [MPSI, Analyse, Suites]
+---
+
+# Analyse – Suites et limites
+
+## Définitions essentielles
+- **Suite réelle** : application \(u : \mathbb{N} \to \mathbb{R}\), notée \((u_n)_{n\geqslant0}\).
+- **Suite convergente** : il existe \(\ell \in \mathbb{R}\) tel que \(\forall \varepsilon>0,\ \exists N:\ n\geqslant N \Rightarrow |u_n-\ell|<\varepsilon\).
+- **Suite divergente vers \(+\infty\)** : \(\forall A\in\mathbb{R},\ \exists N:\ n\geqslant N \Rightarrow u_n>A\).
+- **Suite monotone** : \((u_n)\) croissante si \(u_{n+1}\geqslant u_n\); décroissante si \(u_{n+1}\leqslant u_n\).
+
+## Théorèmes clés
+- **Théorème de convergence monotone** : toute suite réelle monotone et majorée (resp. minorée) converge.
+- **Théorème des gendarmes** : si \(u_n \leqslant v_n \leqslant w_n\) et \(u_n\to \ell, w_n\to \ell\), alors \(v_n\to \ell\).
+- **Suites adjacentes** : si \((u_n)\) croissante, \((v_n)\) décroissante, \(u_n\leqslant v_n\) et \(v_n-u_n\to0\), alors \((u_n)\) et \((v_n)\) convergent vers la même limite.
+- **Théorème de Bolzano-Weierstrass** : toute suite bornée de \(\mathbb{R}\) admet une sous-suite convergente.
+- **Formule de Stolz** (cas sommatoire) : pour des suites réelles \((u_n)\) et \((v_n)\) avec \(v_n\) strictement croissante et \(v_n\to +\infty\), si la limite de \(\frac{u_{n+1}-u_n}{v_{n+1}-v_n}\) existe et vaut \(L\), alors \(\frac{u_n}{v_n}\to L\).
+
+## Méthodes d'étude
+1. **Encadrement** : trouver deux suites simples encadrant \((u_n)\) pour utiliser les gendarmes ou les suites adjacentes.
+2. **Monotonie et bornes** : démontrer la croissance/décroissance et une majoration/minoration.
+3. **Equivalent & croissance comparée** : utiliser les développements limités ou logarithmes pour comparer.
+4. **Transformation** : travailler sur \((u_{n+1}-u_n)\), \((\ln u_n)\) ou sur une relation de récurrence.
+5. **Récurrence pour la convergence** : prouver que \(|u_{n+1}-\ell|\leqslant q|u_n-\ell|\) avec \(|q|<1\).
+
+## Exemples importants
+- \(u_{n+1}=\frac{1}{2}(u_n+\frac{a}{u_n})\) avec \(u_0>0\) converge vers \(\sqrt{a}\).
+- \(u_n = \left(1+\frac{x}{n}\right)^n\to e^x\).
+- \(u_n=\sum_{k=1}^n \frac{1}{k}\) diverge mais \(u_n-\ln n\to \gamma\) (constante d'Euler-Mascheroni).
+- Suites définies par \(u_{n+1}=\cos u_n\) convergent vers l'unique solution de \(x=\cos x\).
+
+## Exercices types
+- Étudier \((u_n)\) définie par récurrence \(u_{n+1}=f(u_n)\) avec \(f\) croissante ou décroissante.
+- Déterminer la limite de suites produits ou puissances \(a_n^{1/n}\), \(n^{1/n}\), etc.
+- Comparer \(\sum_{k=1}^n \frac{1}{k^\alpha}\) à une intégrale pour obtenir l'équivalent.
+- Étudier la convergence d'une suite définie par \(u_n = \frac{1}{n} \sum_{k=1}^n k^p\).
+
+## Connexions utiles
+- Voir [[Analyse – Séries numériques]] pour prolonger l'étude des sommes infinies.
+- Voir [[Analyse – Fonctions d'une variable réelle]] pour les méthodes de limites de fonctions.

--- a/maths-mpsi/Analyse - Séries numériques.md
+++ b/maths-mpsi/Analyse - Séries numériques.md
@@ -1,0 +1,42 @@
+---
+tags: [MPSI, Analyse, Séries]
+---
+
+# Analyse – Séries numériques
+
+## Définitions essentielles
+- **Série** : somme formelle \(\sum_{n=0}^{+\infty} u_n\) d'une suite \((u_n)\).
+- **Somme partielle** : \(S_n = \sum_{k=0}^n u_k\).
+- **Convergence** : la série converge si \((S_n)\) converge vers une limite \(S\).
+- **Série à termes positifs** : tous les \(u_n\geqslant 0\); convergence équivalente à la borne supérieure finie des \(S_n\).
+
+## Théorèmes clés
+- **Test de Cauchy** : \(\sum u_n\) converge si et seulement si \((S_n)\) est de Cauchy.
+- **Critère de comparaison** : si \(0\leqslant u_n\leqslant v_n\) à partir d'un rang et \(\sum v_n\) converge, alors \(\sum u_n\) converge.
+- **Critère des séries géométriques** : \(\sum q^n\) converge si \(|q|<1\) avec somme \(\frac{1}{1-q}\).
+- **Critère de d'Alembert** : \(\limsup \left|\frac{u_{n+1}}{u_n}\right|<1\) implique la convergence absolue.
+- **Critère de Raabe** : si \(n\left(1-\frac{u_{n+1}}{u_n}\right) > 1\) pour \(n\) grand, la série converge.
+- **Test de sommation intégrale** : convergence de \(\int_a^{+\infty} f(t)\,\mathrm{d}t\) équivalente à celle de \(\sum f(n)\) pour \(f\) décroissante positive.
+
+## Méthodes d'étude
+1. **Absolue vs conditionnelle** : commencer par tester la convergence absolue via \(|u_n|\).
+2. **Comparaison** : comparer à une série connue (géométrique, Riemann \(1/n^\alpha\), exponentielle).
+3. **Séries alternées** : utiliser le critère spécial (Leibniz) et majorations du reste.
+4. **Développement limité** : obtenir l'équivalent de \(u_n\) pour décider de la convergence.
+5. **Somme d'une série** : manipuler les sommes partielles, utiliser des séries géométriques ou les séries entières associées.
+
+## Séries classiques
+- Série de Riemann : \(\sum \frac{1}{n^\alpha}\) converge ssi \(\alpha>1\).
+- Série harmonique alternée : \(\sum (-1)^n \frac{1}{n}\) converge conditionnellement vers \(\ln 2\).
+- Série exponentielle : \(\sum \frac{x^n}{n!} = e^x\).
+- Série logarithmique : \(\sum \frac{x^n}{n} = -\ln(1-x)\) pour \(|x|<1\).
+
+## Exercices types
+- Étudier la convergence et sommer \(\sum \frac{(-1)^n}{n(n+1)}\).
+- Comparer \(\sum \frac{\sqrt{n}}{n^2+1}\) à \(\sum \frac{1}{n^{3/2}}\).
+- Utiliser un DL pour décider de la convergence de \(\sum \left(\sqrt{n+1}-\sqrt{n}\right)\).
+- Déterminer un équivalent du reste \(R_n = \sum_{k=n+1}^{+\infty} u_k\).
+
+## Connexions utiles
+- Voir [[Analyse – Suites et limites]] pour les techniques d'équivalents.
+- Voir [[Analyse – Équations différentielles linéaires]] pour les séries génératrices.

--- a/maths-mpsi/Analyse - Équations différentielles linéaires.md
+++ b/maths-mpsi/Analyse - Équations différentielles linéaires.md
@@ -1,0 +1,37 @@
+---
+tags: [MPSI, Analyse, Équations différentielles]
+---
+
+# Analyse – Équations différentielles linéaires
+
+## Définitions essentielles
+- **Équation différentielle linéaire d'ordre 1** : \(y' + a(x)y = b(x)\) sur un intervalle \(I\).
+- **Équation homogène associée** : \(y' + a(x)y = 0\) ; ses solutions forment un espace vectoriel de dimension 1.
+- **Équation d'ordre 2 à coefficients constants** : \(y'' + ay' + by = c(x)\) avec \(a,b\in\mathbb{R}\).
+
+## Théorèmes clés
+- **Existence et unicité** : pour \(a,b\) continues, il existe une unique solution passant par \((x_0, y_0)\).
+- **Méthode de variation de la constante** : solution générale de \(y' + a(x)y = b(x)\) : \(y(x) = e^{-A(x)}\left(\int e^{A(x)}b(x)\,dx + C\right)\) où \(A'(x)=a(x)\).
+- **Superposition** : pour une équation linéaire, la somme de solutions particulières est solution si elles sont associées à des second membres s'additionnant.
+- **Résolution d'ordre 2** : utiliser l'équation caractéristique \(r^2 + ar + b = 0\) et traiter les cas racines simples, doubles, complexes.
+
+## Méthodes usuelles
+1. **Facteur intégrant** : pour l'ordre 1, multiplier par \(\mu(x)=e^{\int a(x)dx}\).
+2. **Recherche d'une solution particulière** : coefficients indéterminés pour second membre polynomial, exponentiel ou trigonométrique.
+3. **Réduction du second ordre à un système** : introduire \(X = (y, y')\) et utiliser les matrices exponentielles.
+4. **Utilisation des conditions initiales** : résoudre les constantes en imposant \(y(x_0)=y_0\), \(y'(x_0)=y_1\).
+5. **Stabilité** : étudier le signe des parties réelles des racines caractéristiques.
+
+## Exemples classiques
+- \(y' - y = e^x\) : solution générale \(y(x) = Ce^{x} + \frac{1}{2} e^{x}(x-1)\).
+- Oscillateur harmonique \(y'' + \omega^2 y = 0\) : solutions \(A\cos \omega x + B\sin \omega x\).
+- Circuit RLC : \(L y'' + R y' + \frac{1}{C} y = E(t)\).
+
+## Exercices types
+- Résoudre \(y'' - 3y' + 2y = e^{2x}\) en déterminant la solution particulière.
+- Étudier le comportement asymptotique des solutions de \(y' + \frac{1}{x}y = \frac{1}{x^2}\) sur \((0,+\infty)\).
+- Vérifier l'indépendance linéaire de solutions via le wronskien.
+
+## Connexions utiles
+- Voir [[Algèbre – Matrices et applications linéaires]] pour l'exponentielle de matrice.
+- Voir [[Analyse – Séries numériques]] pour la résolution via séries formelles.

--- a/maths-mpsi/Géométrie - Produit scalaire et orthogonalité.md
+++ b/maths-mpsi/Géométrie - Produit scalaire et orthogonalité.md
@@ -1,0 +1,39 @@
+---
+tags: [MPSI, Géométrie, Produit scalaire]
+---
+
+# Géométrie – Produit scalaire et orthogonalité
+
+## Définitions essentielles
+- **Produit scalaire** : application symétrique bilinéaire \(\langle u,v\rangle\) définie positive sur un EV réel.
+- **Norme** : \(\|v\| = \sqrt{\langle v,v\rangle}\).
+- **Vecteurs orthogonaux** : \(\langle u,v\rangle = 0\).
+- **Base orthonormée (ON)** : base \((e_i)\) telle que \(\langle e_i,e_j\rangle = \delta_{ij}\).
+
+## Théorèmes clés
+- **Inégalité de Cauchy-Schwarz** : \(|\langle u,v\rangle| \leqslant \|u\|\,\|v\|\).
+- **Identité du parallélogramme** : \(\|u+v\|^2 + \|u-v\|^2 = 2(\|u\|^2 + \|v\|^2)\).
+- **Projection orthogonale** : sur un SEV \(F\) de dimension finie, il existe une unique projection orthogonale.
+- **Théorème de Pythagore** : si \(u\perp v\), alors \(\|u+v\|^2 = \|u\|^2 + \|v\|^2\).
+- **Processus de Gram-Schmidt** : permet d'orthonormaliser une base.
+
+## Méthodes usuelles
+1. **Calcul d'une projection** : \(\operatorname{proj}_F(u) = \sum \frac{\langle u,e_i\rangle}{\|e_i\|^2} e_i\) dans une base orthonormée \((e_i)\).
+2. **Décomposition orthogonale** : \(u = \operatorname{proj}_F(u) + \operatorname{proj}_{F^{\perp}}(u)\).
+3. **Angles et distances** : \(\cos \theta = \frac{\langle u,v\rangle}{\|u\|\,\|v\|}\).
+4. **Utilisation du produit vectoriel en dimension 3** : pour calculer une normale ou une aire orientée.
+5. **Matrice de Gram** : \(G = (\langle v_i,v_j\rangle)\) pour tester l'orthogonalité ou calculer des volumes.
+
+## Exemples clés
+- Calcul de distances point-plan, point-droite dans \(\mathbb{R}^3\).
+- Orthogonalisation d'une base \((1,x,x^2)\) dans \(\mathbb{R}_2[X]\) avec le produit scalaire \(\langle P,Q\rangle = \int_0^1 P(t)Q(t)\,dt\).
+- Recherche de la sphère inscrite à un tétraèdre via projections.
+
+## Exercices types
+- Déterminer la projection orthogonale d'un vecteur sur un plan donné par deux vecteurs directeurs.
+- Construire une base orthonormée à partir de vecteurs \(u,v,w\) libres dans \(\mathbb{R}^3\).
+- Montrer que deux plans sont orthogonaux en utilisant leurs vecteurs normaux.
+
+## Connexions utiles
+- Voir [[Algèbre – Calcul matriciel et déterminants]] pour l'aire/parallélépipède mixte.
+- Voir [[Probabilités – Variables aléatoires discrètes]] pour l'analogie avec l'orthogonalité des fonctions indicatrices.

--- a/maths-mpsi/Probabilités - Variables aléatoires discrètes.md
+++ b/maths-mpsi/Probabilités - Variables aléatoires discrètes.md
@@ -1,0 +1,40 @@
+---
+tags: [MPSI, Probabilités, Variables aléatoires]
+---
+
+# Probabilités – Variables aléatoires discrètes
+
+## Définitions essentielles
+- **Variable aléatoire discrète (VAD)** : application \(X : \Omega \to \mathbb{R}\) prenant un nombre fini ou dénombrable de valeurs.
+- **Loi de probabilité** : \(p_X(x_i) = \mathbb{P}(X=x_i)\) avec \(\sum_i p_X(x_i) = 1\).
+- **Fonction de répartition** : \(F_X(t) = \mathbb{P}(X\leqslant t)\).
+- **Espérance** : \(\mathbb{E}(X) = \sum_i x_i p_X(x_i)\); **variance** \(\operatorname{Var}(X) = \mathbb{E}(X^2) - \mathbb{E}(X)^2\).
+
+## Lois classiques
+- **Bernoulli** \(\mathcal{B}(p)\) : \(\mathbb{P}(X=1)=p\), \(\mathbb{P}(X=0)=1-p\).
+- **Binomiale** \(\mathcal{B}(n,p)\) : somme de \(n\) Bernoulli indépendantes.
+- **Géométrique** \(\mathcal{G}(p)\) : nombre d'essais avant le premier succès.
+- **Poisson** \(\mathcal{P}(\lambda)\) : modèle pour les événements rares; \(\mathbb{P}(X=k)=e^{-\lambda}\frac{\lambda^k}{k!}\).
+
+## Théorèmes et propriétés
+- **Linéarité de l'espérance** : \(\mathbb{E}(aX+bY) = a\mathbb{E}(X) + b\mathbb{E}(Y)\).
+- **Variance d'une somme** : si \(X,Y\) indépendantes, \(\operatorname{Var}(X+Y) = \operatorname{Var}(X)+\operatorname{Var}(Y)\).
+- **Inégalité de Bienaymé-Tchebychev** : \(\mathbb{P}(|X-\mathbb{E}(X)| \geqslant \varepsilon) \leqslant \frac{\operatorname{Var}(X)}{\varepsilon^2}\).
+- **Approximation de Poisson** : pour \(n\) grand, \(\mathcal{B}(n,p)\) s'approxime par \(\mathcal{P}(\lambda)\) avec \(\lambda = np\).
+
+## Méthodes de calcul
+1. **Tableaux de probabilités** : dresser les valeurs et probabilités pour éviter les oublis.
+2. **Utilisation des génératrices** : fonction \(G_X(t) = \mathbb{E}(t^X)\) pour sommer ou calculer espérances.
+3. **Conditionnement** : \(\mathbb{P}(A) = \sum_i \mathbb{P}(A|X=x_i) p_X(x_i)\).
+4. **Indépendance** : vérifier \(\mathbb{P}(X=x, Y=y) = \mathbb{P}(X=x)\mathbb{P}(Y=y)\).
+5. **Formule des probabilités totales** et **de Bayes** pour réviser les probabilités conditionnelles.
+
+## Exercices types
+- Calculer \(\mathbb{E}(X)\) et \(\operatorname{Var}(X)\) pour \(X\sim\mathcal{B}(n,p)\).
+- Étudier la loi du maximum de deux variables indépendantes discrètes.
+- Résoudre un problème d'arrêt optimal simple (jeu à somme finie).
+- Approcher la loi binomiale par une loi de Poisson dans un problème de files d'attente.
+
+## Connexions utiles
+- Voir [[Algèbre – Espaces vectoriels]] pour l'interprétation de l'espérance comme produit scalaire.
+- Voir [[Analyse – Séries numériques]] pour la convergence des séries de probabilités.

--- a/sommaire.md
+++ b/sommaire.md
@@ -1,1 +1,23 @@
-Le sommaire
+# Sommaire des fiches MPSI – Mathématiques
+
+## Analyse
+- [[Analyse – Suites et limites]]
+- [[Analyse – Fonctions d'une variable réelle]]
+- [[Analyse – Séries numériques]]
+- [[Analyse – Intégration sur un segment]]
+- [[Analyse – Équations différentielles linéaires]]
+
+## Algèbre
+- [[Algèbre – Espaces vectoriels]]
+- [[Algèbre – Matrices et applications linéaires]]
+- [[Algèbre – Calcul matriciel et déterminants]]
+
+## Géométrie
+- [[Géométrie – Produit scalaire et orthogonalité]]
+
+## Probabilités
+- [[Probabilités – Variables aléatoires discrètes]]
+
+## Conseils d'utilisation
+- Utiliser les liens bidirectionnels d'Obsidian pour naviguer entre les fiches connexes.
+- Compléter chaque fiche avec vos propres exemples ou corrections d'exercices.


### PR DESCRIPTION
## Summary
- add a structured Obsidian-ready sommaire for the MPSI math notes
- create dedicated analysis, algebra, geometry, and probability fiches with definitions, theorems, and exercises

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce6e8a42c4832d885103f9d2126d57